### PR TITLE
KUBOS-125: split on lines coming back from docker-py in "kubos update"

### DIFF
--- a/kubos/update.py
+++ b/kubos/update.py
@@ -26,16 +26,18 @@ def execCommand(args, following_args):
     print "Checking for latest KubOS-SDK.."
     cli = container.get_cli()
     spinner = status_spinner.start_spinner()
-    for line in cli.pull(repository=container.container_repo, tag=container.container_tag, stream=True):
-       json_data = json.loads(line)
-       if 'error' in json_data:
-            print json_data['error'].encode('utf8')
-       elif 'progress' in json_data:
-            sys.stdout.write('\r%s' % json_data['progress'].encode('utf8'))
-            time.sleep(0.1)
-            sys.stdout.flush()
-       elif 'status' in json_data:
-            print json_data['status'].encode('utf8')
+    for data in cli.pull(repository=container.container_repo,
+                         tag=container.container_tag, stream=True):
+        for line in data.splitlines():
+            json_data = json.loads(line)
+            if 'error' in json_data:
+                print json_data['error'].encode('utf8')
+            elif 'progress' in json_data:
+                sys.stdout.write('\r%s' % json_data['progress'].encode('utf8'))
+                time.sleep(0.1)
+                sys.stdout.flush()
+            elif 'status' in json_data:
+                print json_data['status'].encode('utf8')
     print "All up to date!\n"
     status_spinner.stop_spinner(spinner)
 


### PR DESCRIPTION
this fixes incompatibility with the Docker Mac beta. also cleaned up some 3-space indentation