### PR TITLE
Update the StatusSpinner to be thread-safe in writing to stdout.

### DIFF
--- a/kubos/main.py
+++ b/kubos/main.py
@@ -15,6 +15,7 @@
 
 import argparse
 import json
+import logging
 import os
 import sys
 import subprocess
@@ -39,7 +40,6 @@ def splitList(l, at_value):
 
 def main():
     if os.name == 'nt':
-        import logging
         logging.warning('Windows is not currently supported. Many of the features in the Kubos-sdk will most likely not work correctly or at all on computers running Windows')
 
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
The fundamental problem was one of thread-safety.  This doesn't address some other wokiness that I
see in the way that the docker command outputs are streamed to the parent process' outputs, but that's
a story for another commit.