### PR TITLE
Added slack notifs to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: required
 
+notifications:
+  slack: openkosmos:cMflkK5yPr27bYK0mMRjYsPJ
+
 language: python
 
 python:


### PR DESCRIPTION
This will let Travis post back build notifs to openkosmos' #general channel.

/cc @kubostech/devs @kyleparrott 